### PR TITLE
Add Support for IE11

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "noImplicitAny": false,
     "noFallthroughCasesInSwitch": true,
     "outDir": "lib",
-    "lib": ["ES5", "dom"]
+    "lib": ["es2018", "dom"]
   },
   "exclude": [
     "node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES5",
     "module": "commonjs",
     "moduleResolution": "node",
     "jsx": "react",
@@ -15,7 +15,7 @@
     "noImplicitAny": false,
     "noFallthroughCasesInSwitch": true,
     "outDir": "lib",
-    "lib": ["es2018", "dom"]
+    "lib": ["ES5", "dom"]
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
React hooks itself works great with IE11 but when targeting ES2018 it just breaks. 
Is there any reason why this compiled in es2018?